### PR TITLE
Distro generalization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,9 @@ fn configure_hostname() {
 }
 
 fn run_systemd_tmpfiles() {
+    if !Path::new("/etc/systemd").exists() {
+        return;
+    }
     let args: &[&str] = &[
         "--create",
         "--boot",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -123,7 +123,9 @@ pub fn do_mount(source: &str, target: &str, fstype: &str, flags: usize, fsdata: 
         Some(fsdata_cstr.as_ref()),
     );
     if let Err(err) = result {
-        log!("mount {} -> {}: {}", source, target, err);
+        if err != nix::errno::Errno::ENOENT {
+            log!("mount {} -> {}: {}", source, target, err);
+        }
     }
 }
 


### PR DESCRIPTION
A couple small tweaks to be a bit more distro-agnostic...

 - Many of the paths virtme-ng-init tries to mount are distro-specific and may legitimately not exist; reduce the log noise by only logging mount failures for reasons other than ENOENT.

 - Don't try to run systemd-tmpfiles on non-systemd systems (not sure offhand if there's a better way of testing for systemd's presence than just looking for `/etc/systemd`, but that's what I've done at the moment anyhow).