### PR TITLE
Try to simplify logging a bit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -677,10 +677,7 @@ fn configure_terminal(consdev: &str) {
             .stderr(Stdio::inherit())
             // Replace the current init process with a shell session.
             .output();
-        log!(
-            "{}",
-            String::from_utf8_lossy(&output.unwrap().stderr).trim_end_matches('\n')
-        );
+        log!("{}", String::from_utf8_lossy(&output.unwrap().stderr));
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,7 +41,7 @@ pub fn log_impl(msg: Arguments<'_>) {
     match OpenOptions::new().write(true).open("/dev/kmsg") {
         Ok(mut file) => {
             msg.push('\n');
-            file.write(msg.as_bytes()).ok();
+            file.write_all(msg.as_bytes()).ok();
         }
         Err(_) => {
             println!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,13 @@ use users::get_user_by_name;
 
 static PROG_NAME: &str = "virtme-ng-init";
 
-pub fn log(msg: &str) {
+macro_rules! log {
+    ($($arg:tt)*) => {
+        $crate::utils::log_impl(&std::format!($($arg)*))
+    };
+}
+
+pub fn log_impl(msg: &str) {
     if msg.is_empty() {
         return;
     }
@@ -54,7 +60,7 @@ pub fn do_unlink(path: &str) {
     match std::fs::remove_file(path) {
         Ok(_) => (),
         Err(err) => {
-            log(&format!("failed to unlink file {}: {}", path, err));
+            log!("failed to unlink file {}: {}", path, err);
         }
     }
 }
@@ -68,7 +74,7 @@ fn do_touch(path: &str, mode: u32) {
         Ok(())
     }
     if let Err(err) = _do_touch(path, mode) {
-        log(&format!("error creating file: {}", err));
+        log!("error creating file: {}", err);
     }
 }
 
@@ -86,10 +92,7 @@ pub fn do_symlink(src: &str, dst: &str) {
     match fs::symlink(src, dst) {
         Ok(_) => (),
         Err(err) => {
-            log(&format!(
-                "failed to create symlink {} -> {}: {}",
-                src, dst, err
-            ));
+            log!("failed to create symlink {} -> {}: {}", src, dst, err);
         }
     }
 }
@@ -107,7 +110,7 @@ pub fn do_mount(source: &str, target: &str, fstype: &str, flags: usize, fsdata: 
         Some(fsdata_cstr.as_ref()),
     );
     if let Err(err) = result {
-        log(&format!("mount {} -> {}: {}", source, target, err));
+        log!("mount {} -> {}: {}", source, target, err);
     }
 }
 
@@ -122,15 +125,18 @@ pub fn run_cmd(cmd: impl AsRef<OsStr>, args: &[&str]) {
     match output {
         Ok(output) => {
             if !output.stderr.is_empty() {
-                log(String::from_utf8_lossy(&output.stderr).trim_end_matches('\n'));
+                log!(
+                    "{}",
+                    String::from_utf8_lossy(&output.stderr).trim_end_matches('\n')
+                );
             }
         }
         Err(_) => {
-            log(&format!(
+            log!(
                 "WARNING: failed to run: {:?} {}",
                 cmd.as_ref(),
                 args.join(" ")
-            ));
+            );
         }
     }
 }


### PR DESCRIPTION
In my previous PR, I wrote:

> I also wanted to change the log() function, but didn't come up with any easy and obvious versions and didn't want to dump a macro-mess on you, nor a new dependency like the log or tracing crates.

Turns out this is not as complicated as I first thought! I can just introduce a macro that hides the `format!` in `log(&format!(....))`.

Next, I looked at the standard library. If we press `source` on the [docs of the `print!()` macro](https://doc.rust-lang.org/std/macro.print.html), we learn that this is based on `std::format_args!()`. [Its documentation](https://doc.rust-lang.org/std/macro.format_args.html) indicates that this is some kind of container for the formatted string and can be used in `Display` context to really construct the formatted string. I then went nuts and optimised away the three `String` allocations in the logging implementation into a single allocation. This definitely did not make the code more readable.

As with the last PR: Feel free to do whatever you want with that. Especially the needless logging optimisation can be taken out if you do not like it. Just tell me so and I'll do it.