### PR TITLE
init: set the HOME env var if root

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -753,6 +753,8 @@ fn setup_root_home() {
         utils::do_mkdir("/tmp/roothome");
         utils::do_mount("/tmp/roothome", "/root", "", libc::MS_BIND as usize, "");
         env::set_var("HOME", "/tmp/roothome");
+    } else {
+        env::set_var("HOME", "/root");
     }
 }
 


### PR DESCRIPTION
When virtme-ng was running as root, the HOME dir was set to '/'.

Now it is set to '/root', the expected value.

Fixes: 6ed126b ("virtme-ng-init: docker host support")