### PR TITLE
main.rs: Enable lvm usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,14 @@ fn generate_sudoers() -> io::Result<()> {
     Ok(())
 }
 
+// The /etc/lvm is usually only read/write by root. In order to allow commands like pvcreate to be
+// run on rootless users just create a dummy directory and bind mount it in the same place.
+fn generate_lvm() -> io::Result<()> {
+    utils::do_mkdir("/run/tmp/lvm");
+    utils::do_mount("/run/tmp/lvm", "/etc/lvm/", "", libc::MS_BIND as usize, "");
+    Ok(())
+}
+
 fn generate_hosts() -> io::Result<()> {
     if let Ok(hostname) = env::var("virtme_hostname") {
         std::fs::copy("/etc/hosts", "/run/tmp/hosts")?;
@@ -366,6 +374,7 @@ fn override_system_files() {
     generate_shadow().ok();
     generate_sudoers().ok();
     generate_hosts().ok();
+    generate_lvm().ok();
 }
 
 fn set_cwd() {


### PR DESCRIPTION
Current /etc/lvm/ directories are restricted to root only (700), so just create an empty directory and bind mount over. This is enough to make commands like pvcreate to succeed.

This is my very first Rust code experience, so please let me know if I screwed anything :)

Also, I'm not sure if we have people running virtme-ng with --root and relying on it to access their LVM directories... what do you think about this approach? At least it helped me to create some tests using pv* commands inside a rootless virtme-ng  VM