### PR TITLE
ssh: enable empty password login for all users

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,7 @@ fn generate_shadow() -> io::Result<()> {
 
     for line in reader.lines() {
         if let Some((username, _)) = line?.split_once(':') {
-            writeln!(writer, "{}:!:::::::", username)?;
+            writeln!(writer, "{}::::::::", username)?;
         }
     }
     utils::do_mount(


### PR DESCRIPTION
Disabling password login for all users is unnecessary, as the virtme-ng instance is intended solely for testing purposes.

In fact, enabling empty password for all users can be quite convenient and does not pose a security risk, since all filesystem access is ultimately handled by the host user (due to virtiofsd running as the host user).

In particular, enabling empty password login eliminates the need for managing ssh authorized keys, simplifying the configuration further.